### PR TITLE
Make scheduling more idiomatic

### DIFF
--- a/clockwerk.go
+++ b/clockwerk.go
@@ -46,9 +46,9 @@ func New() *Clockwerk {
 	}
 }
 
-// EverySeconds adds a new Entry to the Clockwerk to be run and returns that Entry.
-func (c *Clockwerk) EverySeconds(seconds uint64) *Entry {
-	entry := newEntry(time.Duration(seconds) * time.Second)
+// Every schedules a new Entry and returns it.
+func (c *Clockwerk) Every(period time.Duration) *Entry {
+	entry := newEntry(period)
 
 	c.schedule(entry)
 

--- a/clockwerk_test.go
+++ b/clockwerk_test.go
@@ -24,8 +24,8 @@ func TestDo(*testing.T) {
 	var job2 DummyJob2
 
 	c := New()
-	c.EverySeconds(1).Do(job1)
-	c.EverySeconds(1).Do(job2)
+	c.Every(1 * time.Second).Do(job1)
+	c.Every(1 * time.Second).Do(job2)
 	defer c.Stop()
 	c.Start()
 

--- a/doc.go
+++ b/doc.go
@@ -14,7 +14,7 @@ them in their own goroutines.
   ...
   var job DummyJob
   c := clockwerk.New()
-  c.EverySeconds(30).Do(job)
+  c.Every(30 * time.Second).Do(job)
   c.Start()
   ...
   // Funcs are invoked in their own goroutine, asynchronously.


### PR DESCRIPTION
This PR replaces `EverySeconds` method with `Every` to leave time unit decision to consumers.

suggested in [here](https://www.reddit.com/r/golang/comments/64y8ac/clockwerk_job_scheduler_my_first_attempt_to/dg5z7t5/) and [here](https://www.reddit.com/r/golang/comments/64y8ac/clockwerk_job_scheduler_my_first_attempt_to/dg62y8r/)