### PR TITLE
Add coveralls specific config for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,11 @@ language: go
 
 go:
   - master
+
+before_install:
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+
+script:
+  - go test -v -covermode=count -coverprofile=coverage.out
+  - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN


### PR DESCRIPTION
This PR enables `coveralls` test coverage service for every build.